### PR TITLE
Add a deref-removing impl for TextSized

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -20,8 +20,7 @@ impl TextSized for &'_ str {
 
 impl<D> TextSized for &'_ D
 where
-    D: Deref,
-    for<'a> &'a D::Target: TextSized,
+    D: Deref<Target = str>,
 {
     #[inline]
     fn text_size(self) -> TextSize {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,4 +1,7 @@
-use {crate::TextSize, std::convert::TryInto};
+use {
+    crate::TextSize,
+    std::{convert::TryInto, ops::Deref},
+};
 
 /// Text-like structures that have a text size.
 pub trait TextSized: Copy {
@@ -12,6 +15,17 @@ impl TextSized for &'_ str {
         self.len()
             .try_into()
             .unwrap_or_else(|_| panic!("string too large ({}) for TextSize", self.len()))
+    }
+}
+
+impl<D> TextSized for &'_ D
+where
+    D: Deref,
+    for<'a> &'a D::Target: TextSized,
+{
+    #[inline]
+    fn text_size(self) -> TextSize {
+        self.deref().text_size()
     }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -34,23 +34,3 @@ impl TextSized for char {
         (self.len_utf8() as u32).into()
     }
 }
-
-// assertion shape from static_assertions::assert_impl_all!
-const _: fn() = || {
-    use std::borrow::Cow;
-
-    fn assert_impl<T: TextSized>() {}
-
-    assert_impl::<&String>();
-    assert_impl::<&Cow<str>>();
-
-    struct StringLike {}
-    impl Deref for StringLike {
-        type Target = str;
-        fn deref(&self) -> &str {
-            unreachable!()
-        }
-    }
-
-    assert_impl::<&StringLike>();
-};

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -34,3 +34,23 @@ impl TextSized for char {
         (self.len_utf8() as u32).into()
     }
 }
+
+// assertion shape from static_assertions::assert_impl_all!
+const _: fn() = || {
+    use std::borrow::Cow;
+
+    fn assert_impl<T: TextSized>() {}
+
+    assert_impl::<&String>();
+    assert_impl::<&Cow<str>>();
+
+    struct StringLike {}
+    impl Deref for StringLike {
+        type Target = str;
+        fn deref(&self) -> &str {
+            unreachable!()
+        }
+    }
+
+    assert_impl::<&StringLike>();
+};

--- a/tests/constructors.rs
+++ b/tests/constructors.rs
@@ -1,0 +1,31 @@
+use {
+    std::{borrow::Cow, ops::Deref},
+    text_size::*,
+};
+
+struct StringLike<'a>(&'a str);
+
+impl Deref for StringLike<'_> {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[test]
+fn main() {
+    let s = "";
+    let _ = TextSize::of(&s);
+
+    let s = String::new();
+    let _ = TextSize::of(&s);
+
+    let s = Cow::Borrowed("");
+    let _ = TextSize::of(&s);
+
+    let s = Cow::Owned(String::new());
+    let _ = TextSize::of(&s);
+
+    let s = StringLike("");
+    let _ = TextSize::of(&s);
+}


### PR DESCRIPTION
Notably, given `s: &SmolStr`, `TextSize::of(s)` does not work, where `TextUnit::of_str(s)` did, because the concrete type could be deref-coerced to. (It's probably a limitation of the language that deref coersion does not apply here, but it's one we have to live with.)

So we provide a blanket impl for any type that derefs (directly) to `str`.

Alternatively, we can provide a deeper blanket impl that derefs any number of references recursively [[playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=008b5e0c2edd332b34b3efa42ce2a40a)]:

```rust
impl<D> TextSized for &'_ D
where
    D: Deref,
    for<'a> &'a D::Target: TextSized,
{
    #[inline]
    fn text_size(self) -> TextSize {
        self.deref().text_size()
    }
}
```

This is "only" at the cost of a little extra impl complexity.