### PR TITLE
Make TextRange constructors more boring

### DIFF
--- a/src/serde_impls.rs
+++ b/src/serde_impls.rs
@@ -17,7 +17,7 @@ impl<'de> Deserialize<'de> for TextSize {
     where
         D: Deserializer<'de>,
     {
-        Deserialize::deserialize(deserializer).map(TextSize)
+        u32::deserialize(deserializer).map(TextSize::from)
     }
 }
 
@@ -43,6 +43,6 @@ impl<'de> Deserialize<'de> for TextRange {
                 start, end
             )));
         }
-        Ok(TextRange(start, end))
+        Ok(TextRange::new(start, end))
     }
 }

--- a/src/size.rs
+++ b/src/size.rs
@@ -33,11 +33,6 @@ pub struct TextSize {
     pub(crate) raw: u32,
 }
 
-#[allow(non_snake_case)]
-pub(crate) const fn TextSize(raw: u32) -> TextSize {
-    TextSize { raw }
-}
-
 impl fmt::Debug for TextSize {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.raw)
@@ -57,7 +52,7 @@ impl TextSize {
     /// but is more explicit on intent.
     #[inline]
     pub const fn zero() -> TextSize {
-        TextSize(0)
+        TextSize { raw: 0 }
     }
 }
 
@@ -65,27 +60,27 @@ impl TextSize {
 //  Last updated for parity with Rust 1.42.0.
 impl TextSize {
     /// The smallest representable text size. (`u32::MIN`)
-    pub const MIN: TextSize = TextSize(u32::MIN);
+    pub const MIN: TextSize = TextSize { raw: u32::MIN };
     /// The largest representable text size. (`u32::MAX`)
-    pub const MAX: TextSize = TextSize(u32::MAX);
+    pub const MAX: TextSize = TextSize { raw: u32::MAX };
 
     /// Checked addition. Returns `None` if overflow occurred.
     #[inline]
     pub fn checked_add(self, rhs: TextSize) -> Option<TextSize> {
-        self.raw.checked_add(rhs.raw).map(TextSize)
+        self.raw.checked_add(rhs.raw).map(|raw| TextSize { raw })
     }
 
     /// Checked subtraction. Returns `None` if overflow occurred.
     #[inline]
     pub fn checked_sub(self, rhs: TextSize) -> Option<TextSize> {
-        self.raw.checked_sub(rhs.raw).map(TextSize)
+        self.raw.checked_sub(rhs.raw).map(|raw| TextSize { raw })
     }
 }
 
 impl From<u32> for TextSize {
     #[inline]
     fn from(raw: u32) -> Self {
-        TextSize(raw)
+        TextSize { raw }
     }
 }
 
@@ -117,7 +112,7 @@ macro_rules! ops {
             type Output = TextSize;
             #[inline]
             fn $f(self, other: TextSize) -> TextSize {
-                TextSize(self.raw $op other.raw)
+                TextSize { raw: self.raw $op other.raw }
             }
         }
         impl $Op<&TextSize> for TextSize {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -18,6 +18,6 @@ impl TextSized for &'_ str {
 impl TextSized for char {
     #[inline]
     fn text_size(self) -> TextSize {
-        TextSize(self.len_utf8() as u32)
+        (self.len_utf8() as u32).into()
     }
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -5,7 +5,7 @@ fn size(x: u32) -> TextSize {
 }
 
 fn range(x: ops::Range<u32>) -> TextRange {
-    TextRange(x.start.into(), x.end.into())
+    TextRange::new(x.start.into(), x.end.into())
 }
 
 #[test]

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -5,7 +5,7 @@ fn size(x: u32) -> TextSize {
 }
 
 fn range(x: ops::Range<u32>) -> TextRange {
-    TextRange(x.start.into(), x.end.into())
+    TextRange::new(x.start.into(), x.end.into())
 }
 
 #[test]


### PR DESCRIPTION
Remove `fn TextRange(` as that's slightly unusual and surprising,
which will add up to a lot of confusion over the long run.

Instead add:

* `new` as the biased, canonical way to create range from bounds
* `from_len` as an alternative ctor from starting position and len
* `empty` for empty ranges at a given offset
* `up_to` for ranges at zero offset with given length
* `default` for an empty range at zero