### PR TITLE
Don't use decimal numbers when str length overflows TextSize.

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -12,9 +12,7 @@ pub trait LenTextSize: Copy {
 impl LenTextSize for &'_ str {
     #[inline]
     fn len_text_size(self) -> TextSize {
-        self.len()
-            .try_into()
-            .unwrap_or_else(|_| panic!("string too large ({}) for TextSize", self.len()))
+        self.len().try_into().unwrap()
     }
 }
 


### PR DESCRIPTION
Since the string is necessarily longer than 4,294,967,296 bytes,
it is probably more useful to output the length in hexadecimal.

For additional niceness, we output the first and last 10 characters.