### PR TITLE
Use standard generics for TextSize::of

### DIFF
--- a/src/size.rs
+++ b/src/size.rs
@@ -57,7 +57,7 @@ impl TextSize {
     /// assert_eq!(str_size, TextSize::from(13));
     /// ```
     #[inline]
-    pub fn of(text: impl LenTextSize) -> TextSize {
+    pub fn of<T: LenTextSize>(text: T) -> TextSize {
         text.len_text_size()
     }
 


### PR DESCRIPTION
There is no specific reason to use APIT here, so prefer the form that allows more control for the user, in the form of the turbofish.