### PR TITLE
Actually fail CI for doc warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,11 @@ on:
     - staging
     - trying
 
+env:
+  RUSTFLAGS: -D warnings
+  RUSTUP_MAX_RETRIES: 10
+  CARGO_NET_RETRY: 10
+
 jobs:
   rust:
     name: Rust
@@ -16,11 +21,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-
-    env:
-      RUSTFLAGS: -D warnings
-      RUSTUP_MAX_RETRIES: 10
-      CARGO_NET_RETRY: 10
 
     steps:
     - name: Checkout repository
@@ -39,11 +39,6 @@ jobs:
     name: Docs
     runs-on: ubuntu-latest
 
-    env:
-      RUSTFLAGS: -D warnings
-      RUSTUP_MAX_RETRIES: 10
-      CARGO_NET_RETRY: 10
-
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -53,6 +48,7 @@ jobs:
       with:
         toolchain: nightly
         profile: minimal
+        override: true
 
     - name: Rustdoc
-      run: cargo doc --all-features
+      run: cargo rustdoc --all-features -- -D warnings


### PR DESCRIPTION
This should fail without a further PR to fix the broken intra doc link, if this is doing what it should do.