### PR TITLE
Re-add Index<TextRange> for String

### DIFF
--- a/src/range.rs
+++ b/src/range.rs
@@ -305,14 +305,29 @@ impl TextRange {
 impl Index<TextRange> for str {
     type Output = str;
     #[inline]
-    fn index(&self, index: TextRange) -> &Self::Output {
+    fn index(&self, index: TextRange) -> &str {
+        &self[Range::<usize>::from(index)]
+    }
+}
+
+impl Index<TextRange> for String {
+    type Output = str;
+    #[inline]
+    fn index(&self, index: TextRange) -> &str {
         &self[Range::<usize>::from(index)]
     }
 }
 
 impl IndexMut<TextRange> for str {
     #[inline]
-    fn index_mut(&mut self, index: TextRange) -> &mut Self::Output {
+    fn index_mut(&mut self, index: TextRange) -> &mut str {
+        &mut self[Range::<usize>::from(index)]
+    }
+}
+
+impl IndexMut<TextRange> for String {
+    #[inline]
+    fn index_mut(&mut self, index: TextRange) -> &mut str {
         &mut self[Range::<usize>::from(index)]
     }
 }

--- a/tests/indexing.rs
+++ b/tests/indexing.rs
@@ -1,0 +1,8 @@
+use text_size::*;
+
+#[test]
+fn main() {
+    let range = TextRange::default();
+    &""[range];
+    &String::new()[range];
+}


### PR DESCRIPTION
These exist in `text_unit`, and seem to be required to index `String`. (Why doesn't deref coersion kick in here? I don't know.)