### PR TITLE
Provide LenTextSize for Arc<String>

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -16,9 +16,9 @@ impl LenTextSize for &'_ str {
     }
 }
 
-impl<D> LenTextSize for &'_ D
+impl<D: Deref> LenTextSize for &'_ D
 where
-    D: Deref<Target = str>,
+    for<'a> &'a D::Target: LenTextSize,
 {
     #[inline]
     fn len_text_size(self) -> TextSize {

--- a/tests/constructors.rs
+++ b/tests/constructors.rs
@@ -1,5 +1,5 @@
 use {
-    std::{borrow::Cow, ops::Deref},
+    std::{borrow::Cow, ops::Deref, sync::Arc},
     text_size::*,
 };
 
@@ -14,18 +14,22 @@ impl Deref for StringLike<'_> {
 
 #[test]
 fn main() {
-    let s = "";
-    let _ = TextSize::of(&s);
+    macro_rules! test {
+        ($($expr:expr),+ $(,)?) => {
+            $({
+                let s = $expr;
+                let _ = TextSize::of(&s);
+            })+
+        };
+    }
 
-    let s = String::new();
-    let _ = TextSize::of(&s);
-
-    let s = Cow::Borrowed("");
-    let _ = TextSize::of(&s);
-
-    let s = Cow::Owned(String::new());
-    let _ = TextSize::of(&s);
-
-    let s = StringLike("");
-    let _ = TextSize::of(&s);
+    test! {
+        "",
+        String::new(),
+        Cow::Borrowed(""),
+        Cow::Owned::<str>(String::new()),
+        StringLike(""),
+        Arc::new(""),
+        Arc::new(String::new()),
+    }
 }


### PR DESCRIPTION
_Unfortunately_, this impl leads to infinite recursion for, say `&()`, or any reference type that doesn't impl `LenTextSize`. `Cow::Owned(String::new())` falls into this trap via the type inference variable for the `B` in `Cow<'_, B>`.

I've [reported the wonderful error](https://github.com/rust-lang/rust/issues/47720#issuecomment-604187222) which isn't even being caught by the "recursive requirements" folder.

I have some alternate constructions to try, but I'm putting this one in the pool before I forget that `&Arc<String>` should be accepted by `TextSize::of`.