### PR TITLE
Rename LenTextSize => TextLen

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ mod traits;
 #[cfg(feature = "serde")]
 mod serde_impls;
 
-pub use crate::{range::TextRange, size::TextSize, traits::LenTextSize};
+pub use crate::{range::TextRange, size::TextSize, traits::TextLen};
 
 #[cfg(target_pointer_width = "16")]
 compile_error!("text-size assumes usize >= u32 and does not work on 16-bit targets");

--- a/src/size.rs
+++ b/src/size.rs
@@ -1,5 +1,5 @@
 use {
-    crate::LenTextSize,
+    crate::TextLen,
     std::{
         convert::TryFrom,
         fmt, iter,
@@ -44,7 +44,7 @@ impl TextSize {
     ///
     /// Accepts `char`, `&str`, and references to any custom string-like type
     /// that dereferences to `str`. Types that don't dereference to `str` but
-    /// want to be usable in this constructor can implement [`LenTextSize`].
+    /// want to be usable in this constructor can implement [`TextLen`].
     ///
     /// # Examples
     ///
@@ -57,8 +57,8 @@ impl TextSize {
     /// assert_eq!(str_size, TextSize::from(13));
     /// ```
     #[inline]
-    pub fn of<T: LenTextSize>(text: T) -> TextSize {
-        text.len_text_size()
+    pub fn of<T: TextLen>(text: T) -> TextSize {
+        text.text_len()
     }
 
     /// A size of zero.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -4,52 +4,52 @@ use {
 };
 
 /// Text-like structures that have a text size.
-pub trait LenTextSize: Copy {
+pub trait TextLen: Copy {
     /// The size of this text-alike.
-    fn len_text_size(self) -> TextSize;
+    fn text_len(self) -> TextSize;
 }
 
-impl LenTextSize for &'_ str {
+impl TextLen for &'_ str {
     #[inline]
-    fn len_text_size(self) -> TextSize {
+    fn text_len(self) -> TextSize {
         self.len().try_into().unwrap()
     }
 }
 
-impl LenTextSize for char {
+impl TextLen for char {
     #[inline]
-    fn len_text_size(self) -> TextSize {
+    fn text_len(self) -> TextSize {
         (self.len_utf8() as u32).into()
     }
 }
 
-impl<D> LenTextSize for &'_ D
+impl<D> TextLen for &'_ D
 where
-    D: LenTextSize + Copy,
+    D: TextLen + Copy,
 {
-    fn len_text_size(self) -> TextSize {
-        D::len_text_size(*self)
+    fn text_len(self) -> TextSize {
+        D::text_len(*self)
     }
 }
 
 // Because we could not find a smart blanket impl to do this automatically and
 // cleanly (rust-analyzer/text-size#36), just provide a bunch of manual impls.
-// If a type fits in this macro and you need it to impl LenTextSize, just open
-// a PR and we are likely to accept it. Or use `TextSize::of::<&str>` for now.
-macro_rules! impl_lentextsize_for_string {
+// If a standard type fits in this macro and you need it to impl TextLen, just
+// open a PR and we are likely to accept it. Or convince Rust to deref to &str.
+macro_rules! impl_textlen_for_string {
     ($($ty:ty),+ $(,)?) => {$(
-        impl LenTextSize for $ty {
+        impl TextLen for $ty {
             #[inline]
-            fn len_text_size(self) -> TextSize {
-                <&str>::len_text_size(self)
+            fn text_len(self) -> TextSize {
+                <&str>::text_len(self)
             }
         }
     )+};
 }
 
-impl_lentextsize_for_string! {
+impl_textlen_for_string! {
     &Box<str>,
-    &'_ String,
+    &String,
     &Cow<'_, str>,
     &Cow<'_, String>,
     &Arc<str>,

--- a/tests/constructors.rs
+++ b/tests/constructors.rs
@@ -6,8 +6,8 @@ use {
 #[derive(Copy, Clone)]
 struct BadRope<'a>(&'a [&'a str]);
 
-impl LenTextSize for BadRope<'_> {
-    fn len_text_size(self) -> TextSize {
+impl TextLen for BadRope<'_> {
+    fn text_len(self) -> TextSize {
         self.0.iter().map(TextSize::of).sum()
     }
 }


### PR DESCRIPTION
This way, it's a reasonable name to use. Closes #38 

I still think `TextSize::of` should be the primarily recommended construction interface (thus keeping the `TextLen` macro impls for standard types), but calling `.text_len()` is a friendlier alternative for when deref coercion is desired to kick in.