### PR TITLE
Fix TextSize::of docs to no longer suggest implementing TextLen

### DIFF
--- a/src/size.rs
+++ b/src/size.rs
@@ -33,11 +33,9 @@ impl fmt::Debug for TextSize {
 }
 
 impl TextSize {
-    /// The text size of some text-like object.
+    /// The text size of some primitive text-like object.
     ///
-    /// Accepts `char`, `&str`, and references to any custom string-like type
-    /// that dereferences to `str`. Types that don't dereference to `str` but
-    /// want to be usable in this constructor can implement [`TextLen`].
+    /// Accepts `char`, `&str`, and `&String`.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Addresses the misleading docs part of #45 by editing the docs back to their minimum. Does not yet provide advice on idioms for non-primitive types.