### PR TITLE
Make text-size no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ description = "Newtypes for text offsets"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-analyzer/text-size"
 documentation = "https://docs.rs/text-size"
+categories = ["no-std"]
 
 [dependencies]
 serde = { version = "1.0", optional = true, default_features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,9 @@
 
 #![forbid(unsafe_code)]
 #![warn(missing_debug_implementations, missing_docs)]
+#![no_std]
+
+extern crate alloc;
 
 mod range;
 mod size;

--- a/src/range.rs
+++ b/src/range.rs
@@ -1,6 +1,7 @@
 use {
     crate::TextSize,
-    std::{
+    alloc::string::String,
+    core::{
         cmp, fmt,
         ops::{Add, AddAssign, Bound, Index, IndexMut, Range, RangeBounds, Sub, SubAssign},
     },

--- a/src/serde_impls.rs
+++ b/src/serde_impls.rs
@@ -1,5 +1,6 @@
 use {
     crate::{TextRange, TextSize},
+    alloc::format,
     serde::{de, Deserialize, Deserializer, Serialize, Serializer},
 };
 

--- a/src/size.rs
+++ b/src/size.rs
@@ -1,6 +1,6 @@
 use {
     crate::TextLen,
-    std::{
+    core::{
         convert::TryFrom,
         fmt, iter,
         num::TryFromIntError,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,4 +1,4 @@
-use {crate::TextSize, std::convert::TryInto};
+use {crate::TextSize, alloc::string::String, core::convert::TryInto};
 
 use priv_in_pub::Sealed;
 mod priv_in_pub {


### PR DESCRIPTION
I'm creating a parser (and later interpreter) for a language called (jsonnet)[https://jsonnet.org/], and I'm using rowan to do so. The parser at this point is mostly done (or so it seems to me at least 😛), however, I would like to really inspect the output from it in a visual way. To do so, I plan to employ [ast explorer](https://astexplorer.net/) for which I think the best way to do so is to compile the whole thing to web assembly (it's a goal of mine to compile the interpreter to web assembly eventually anyway, this just got me started on that bit a bit earlier than planned).

Now; this repo obviously isn't rowan, but it is a dependency of rowan, so I figured I'd start small to test out the waters and get the discussion started. I've never done web assembly or `no_std` before, so I'm not sure this is the correct way to go about it, so I was hoping to get some input while I'm still working with easy things (very little changes in this PR after all). If there are any changes you would like, or any suggestions you have, please let me know.